### PR TITLE
feat: Refactor architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -82,6 +82,15 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -168,7 +177,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -201,7 +210,6 @@ dependencies = [
  "cranelift-entity 0.104.0",
  "logos",
  "miette",
- "petgraph",
  "pretty_assertions",
  "thiserror",
  "wasm-encoder 0.38.1",
@@ -478,12 +486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "is_ci"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itertools"
@@ -714,7 +716,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.39",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -761,32 +763,32 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "3.3.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2adcfcced5d625bf90a958a82ae5b93231f57f3df1383fee28c9b5096d35ed"
+checksum = "baed61d13cc3723ee6dbed730a82bfacedc60a85d81da2d77e9c3e8ebc0b504a"
 dependencies = [
- "atty",
  "backtrace",
+ "backtrace-ext",
  "miette-derive",
- "once_cell",
  "owo-colors",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap 0.14.2",
+ "textwrap",
  "thiserror",
+ "unicode-width",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "3.3.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a8b61312d367ce87956bb686731f87e4c6dd5dbc550e8f06e3c24fb1f67f"
+checksum = "f301c3f54f98abc6c212ee722f5e5c62e472a334415840669e356f04850051ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -824,25 +826,15 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "petgraph"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
-dependencies = [
- "fixedbitset",
- "indexmap 2.1.0",
-]
 
 [[package]]
 name = "pkg-config"
@@ -892,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -910,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1066,7 +1058,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1129,31 +1121,24 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "supports-color"
-version = "1.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
 dependencies = [
- "atty",
  "is_ci",
 ]
 
 [[package]]
 name = "supports-hyperlinks"
-version = "1.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590b34f7c5f01ecc9d78dba4b3f445f31df750a67621cf31626f3b7441ce6406"
-dependencies = [
- "atty",
-]
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
 
 [[package]]
 name = "supports-unicode"
-version = "1.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b945e45b417b125a8ec51f1b7df2f8df7920367700d1f98aedd21e5735f8b2"
-dependencies = [
- "atty",
-]
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -1168,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1194,23 +1179,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1218,25 +1192,30 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1422,7 +1401,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.49",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -1614,7 +1593,7 @@ checksum = "f50f51f8d79bfd2aa8e9d9a0ae7c2d02b45fe412e62ff1b87c0c81b07c738231"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1892,7 +1871,7 @@ checksum = "be912bf68235a88fbefd1b73415cb218405958d1655b2ece9035a19920bdf6ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ path = "src/bin.rs"
 [dependencies]
 clap = { version = "3.0.0-rc.7", features = ["derive"] }
 thiserror = "1.0.30"
-miette = { version = "3.3.0", features = ["fancy"] }
+miette = { version = "7.1.0", features = ["fancy"] }
 logos = "0.13.0"
-petgraph = "0.6.4"
 wasm-encoder = "0.38"
 cranelift-entity = "0.104.0"
 

--- a/src/ast/component.rs
+++ b/src/ast/component.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
+
 use cranelift_entity::{entity_impl, PrimaryMap};
 
+use crate::ast;
 use crate::ast::expressions::ExpressionData;
+use crate::Source;
 
 use super::{
-    expressions::ExpressionId,
-    types::{FnType, ValType},
-    Call, NameId, Span, M,
+    expressions::ExpressionId, statements::StatementId, types::FnType, NameId, Span, TypeId, ValType
 };
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -22,20 +24,117 @@ entity_impl!(FunctionId, "func");
 
 /// Each Claw source file represents a Component
 /// and this struct represents the root of the AST.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Component {
+    pub src: Source,
+
     // Top level items
     pub imports: PrimaryMap<ImportId, Import>,
     pub globals: PrimaryMap<GlobalId, Global>,
     pub functions: PrimaryMap<FunctionId, Function>,
+
+    // Inner items
+    pub types: PrimaryMap<TypeId, ValType>,
+    pub type_spans: HashMap<TypeId, Span>,
+
+    pub statements: PrimaryMap<StatementId, ast::Statement>,
+    pub statement_spans: HashMap<StatementId, Span>,
+
+    pub expression_data: ExpressionData,
+
+    pub names: PrimaryMap<NameId, String>,
+    pub name_spans: HashMap<NameId, Span>,
+}
+
+impl Component {
+    pub fn new(src: crate::Source) -> Self {
+        Self {
+            src,
+            imports: Default::default(),
+            globals: Default::default(),
+            functions: Default::default(),
+            types: Default::default(),
+            type_spans: Default::default(),
+            statements: Default::default(),
+            statement_spans: Default::default(),
+            expression_data: Default::default(),
+            names: Default::default(),
+            name_spans: Default::default(),
+        }
+    }
+
+    pub fn new_name(&mut self, name: String, span: Span) -> NameId {
+        let id = self.names.push(name);
+        self.name_spans.insert(id, span);
+        id
+    }
+
+    pub fn get_name(&self, id: NameId) -> &str {
+        self.names.get(id).unwrap()
+    }
+
+    pub fn name_span(&self, id: NameId) -> Span {
+        self.name_spans.get(&id).unwrap().clone()
+    }
+
+    pub fn new_type(&mut self, valtype: ValType, span: Span) -> TypeId {
+        let id = self.types.push(valtype);
+        self.type_spans.insert(id, span);
+        id
+    }
+
+    pub fn get_type(&self, id: TypeId) -> &ValType {
+        self.types.get(id).unwrap()
+    }
+
+    pub fn type_span(&self, id: TypeId) -> Span {
+        self.type_spans.get(&id).unwrap().clone()
+    }
+
+    pub fn new_statement(&mut self, statement: ast::Statement, span: Span) -> StatementId {
+        let id = self.statements.push(statement);
+        self.statement_spans.insert(id, span);
+        id
+    }
+
+    pub fn get_statement(&self, id: StatementId) -> &ast::Statement {
+        self.statements.get(id).unwrap()
+    }
+
+    pub fn statement_span(&self, id: StatementId) -> Span {
+        self.statement_spans.get(&id).unwrap().clone()
+    }
+
+    pub fn alloc_let(
+        &mut self,
+        mutable: bool,
+        ident: NameId,
+        annotation: Option<TypeId>,
+        expression: ExpressionId,
+        span: Span,
+    ) -> StatementId {
+        let let_ = ast::Let {
+            mutable,
+            ident,
+            annotation,
+            expression,
+        };
+        self.new_statement(ast::Statement::Let(let_), span)
+    }
+
+    pub fn expr(&self) -> &ExpressionData {
+        &self.expression_data
+    }
+
+    pub fn expr_mut(&mut self) -> &mut ExpressionData {
+        &mut self.expression_data
+    }
 }
 
 ///
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Import {
-    pub import_kwd: Span,
-    pub name: M<String>,
-    pub colon: Span,
+    pub ident: NameId,
     pub external_type: ExternalType,
 }
 
@@ -48,68 +147,23 @@ pub enum ExternalType {
 ///
 #[derive(Debug)]
 pub struct Function {
-    pub export_kwd: Option<Span>,
+    pub exported: bool,
     pub signature: FunctionSignature,
-    pub body: M<Block>,
-    pub expressions: ExpressionData,
+    pub body: Vec<StatementId>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FunctionSignature {
-    pub name: M<String>,
-    pub colon: Span,
+    pub ident: NameId,
     pub fn_type: FnType,
 }
 
 ///
 #[derive(Debug, Clone)]
 pub struct Global {
-    pub export_kwd: Option<Span>,
-    pub let_kwd: Span,
-    pub mut_kwd: Option<Span>,
-    pub ident: M<String>,
-    pub colon: Span,
-    pub valtype: M<ValType>,
-    pub assign: Span,
+    pub exported: bool,
+    pub mutable: bool,
+    pub ident: NameId,
+    pub type_id: TypeId,
     pub init_value: ExpressionId,
-    pub semicolon: Span,
-    pub expressions: ExpressionData,
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct Block {
-    pub start_brace: Span,
-    pub statements: Vec<M<Statement>>,
-    pub end_brace: Span,
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub enum Statement {
-    Let {
-        let_kwd: Span,
-        mut_kwd: Option<Span>,
-        ident: M<String>,
-        name_id: NameId,
-        annotation: Option<M<ValType>>,
-        assign_op: Span,
-        expression: ExpressionId,
-    },
-    Assign {
-        ident: M<String>,
-        name_id: NameId,
-        assign_op: Span,
-        expression: ExpressionId,
-    },
-    Call {
-        call: Call,
-    },
-    If {
-        if_kwd: Span,
-        condition: ExpressionId,
-        block: M<Block>,
-    },
-    Return {
-        return_kwd: Span,
-        expression: ExpressionId,
-    },
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,71 +1,17 @@
-use std::sync::atomic;
-use std::sync::atomic::AtomicUsize;
-
 pub mod component;
 pub mod expressions;
+pub mod statements;
 pub mod types;
 
+use cranelift_entity::entity_impl;
 use miette::SourceSpan;
 
 pub type Span = SourceSpan;
 
 pub use component::*;
 pub use expressions::*;
+pub use statements::*;
 pub use types::*;
-
-/// The metadata wrapper type
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub struct M<T> {
-    pub span: Span,
-    pub value: T,
-}
-
-impl<T> AsRef<T> for M<T> {
-    fn as_ref(&self) -> &T {
-        &self.value
-    }
-}
-
-impl<T> M<T> {
-    pub fn new(value: T, span: Span) -> Self {
-        M { span, value }
-    }
-
-    pub fn new_range(value: T, left: Span, right: Span) -> Self {
-        let span = merge(&left, &right);
-        M { span, value }
-    }
-}
-
-/// The metadata wrapper type
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub struct MBox<T> {
-    pub span: Span,
-    pub value: Box<T>,
-}
-
-impl<T> MBox<T> {
-    pub fn new(value: T, span: Span) -> Self {
-        MBox {
-            span,
-            value: Box::new(value),
-        }
-    }
-
-    pub fn new_range(value: T, left: Span, right: Span) -> Self {
-        let span = merge(&left, &right);
-        MBox {
-            span,
-            value: Box::new(value),
-        }
-    }
-}
-
-impl<T> AsRef<T> for MBox<T> {
-    fn as_ref(&self) -> &T {
-        &self.value
-    }
-}
 
 pub fn merge(left: &Span, right: &Span) -> Span {
     let left_most = left.offset();
@@ -74,12 +20,21 @@ pub fn merge(left: &Span, right: &Span) -> Span {
     Span::from((left_most, len))
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct NameId(usize);
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NameId(u32);
+entity_impl!(NameId, "name");
 
-impl NameId {
-    pub fn new() -> Self {
-        static NAME_COUNTER: AtomicUsize = AtomicUsize::new(0usize);
-        NameId(NAME_COUNTER.fetch_add(1usize, atomic::Ordering::SeqCst))
+#[cfg(test)]
+impl ContextEq<Component> for NameId {
+    fn context_eq(&self, other: &Self, context: &Component) -> bool {
+        let self_str = context.get_name(*self);
+        let other_str = context.get_name(*other);
+        let str_eq = self_str == other_str;
+
+        let self_span = context.name_span(*self);
+        let other_span = context.name_span(*other);
+        let span_eq = self_span == other_span;
+
+        str_eq && span_eq
     }
 }

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -1,0 +1,41 @@
+use cranelift_entity::entity_impl;
+
+use super::{expressions::ExpressionId, types::TypeId, Call, NameId};
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StatementId(u32);
+entity_impl!(StatementId, "name");
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Statement {
+    Let(Let),
+    Assign(Assign),
+    Call(Call),
+    If(If),
+    Return(Return),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Let {
+    pub mutable: bool,
+    pub ident: NameId,
+    pub annotation: Option<TypeId>,
+    pub expression: ExpressionId,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Assign {
+    pub ident: NameId,
+    pub expression: ExpressionId,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct If {
+    pub condition: ExpressionId,
+    pub block: Vec<StatementId>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Return {
+    pub expression: ExpressionId,
+}

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1,15 +1,26 @@
-use super::{MBox, Span, M};
+use cranelift_entity::entity_impl;
+
+use super::{NameId, Component};
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TypeId(u32);
+entity_impl!(TypeId, "type");
 
 /// The type for all values
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Hash, Clone)]
 pub enum ValType {
+    // TypeName(NameId),
+
     // Result Type
-    Result {
-        ok: MBox<ValType>,
-        err: MBox<ValType>,
-    },
+    Result { ok: TypeId, err: TypeId },
+
     // String Type
     String,
+    Primitive(PrimitiveType),
+}
+
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+pub enum PrimitiveType {
     // Unsigned Integers
     U64,
     U32,
@@ -21,15 +32,49 @@ pub enum ValType {
     S16,
     S8,
     // Floating Point Numbers
-    F32,
     F64,
+    F32,
     // The boolean type
     Bool,
 }
 
+impl ValType {
+    pub fn eq(&self, other: &Self, comp: &Component) -> bool {
+        match (self, other) {
+            (
+                ValType::Result {
+                    ok: l_ok,
+                    err: l_err,
+                },
+                ValType::Result {
+                    ok: r_ok,
+                    err: r_err,
+                },
+            ) => {
+                let l_ok = comp.get_type(*l_ok);
+                let r_ok = comp.get_type(*r_ok);
+                let ok_eq = l_ok.eq(r_ok, comp);
+
+                let l_err = comp.get_type(*l_err);
+                let r_err = comp.get_type(*r_err);
+                let err_eq = l_err.eq(r_err, comp);
+
+                ok_eq && err_eq
+            }
+            (ValType::String, ValType::String) => true,
+            (ValType::Primitive(left), ValType::Primitive(right)) => left == right,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum TypeDefinition {
+    // TODO
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct FnType {
-    pub arguments: Vec<(M<String>, M<ValType>)>,
-    pub arrow: Span,
-    pub return_type: M<ValType>,
+    pub arguments: Vec<(NameId, TypeId)>,
+    pub return_type: TypeId,
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -64,7 +64,14 @@ impl Compile {
         };
 
         let generator = claw::codegen::CodeGenerator::default();
-        let wasm = generator.generate(&resolved);
+        let wasm = match generator.generate(&resolved) {
+            Ok(wasm) => wasm,
+            Err(error) => {
+                println!("{:?}", Report::new(error));
+                return None;
+            },
+        };
+
         match fs::write(&self.output, wasm) {
             Ok(_) => println!("Done"),
             Err(err) => println!("Error: {:?}", err),

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,13 +1,13 @@
 use crate::{
-    ast::{
-        self, expressions::Literal, types::ValType, BinaryOp, ExpressionId, FnType, FunctionId, Import, ImportId
-    },
-    resolver::{FunctionResolver, ItemId, ResolvedComponent},
+    ast::{self, ExpressionId, FunctionId, ImportId, StatementId, TypeId}, context::{WithContext, C}, resolver::{FunctionResolver, ItemId, ResolvedComponent, ResolvedType, ResolverError}
 };
+use miette::Diagnostic;
+use thiserror::Error;
 
 use cranelift_entity::EntityRef;
 use enc::ModuleArg;
 use wasm_encoder as enc;
+use wasm_encoder::Instruction;
 
 const MODULE_IDX: u32 = 0;
 
@@ -18,6 +18,13 @@ const MODULE_INSTANCE_IDX: u32 = 1;
 pub struct CodeGenerator {
     module: ModuleBuilder,
     component: ComponentBuilder,
+}
+
+#[derive(Error, Debug, Diagnostic)]
+pub enum GenerationError {
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Resolver(#[from] ResolverError)
 }
 
 /// Module Index Spaces
@@ -50,33 +57,39 @@ pub struct ComponentBuilder {
 }
 
 impl CodeGenerator {
-    pub fn generate(mut self, resolved_comp: &ResolvedComponent) -> Vec<u8> {
+    pub fn generate(mut self, resolved_comp: &ResolvedComponent) -> Result<Vec<u8>, GenerationError> {
         self.encode_globals(resolved_comp);
 
         for (id, import) in resolved_comp.component.imports.iter() {
-            self.encode_import(id, import);
+            self.encode_import(id, import, resolved_comp);
         }
 
         for (id, function) in resolved_comp.component.functions.iter() {
-            self.encode_func(id, function, resolved_comp);
+            self.encode_func(id, function, resolved_comp)?;
         }
 
-        self.emit_bytes()
+        Ok(self.emit_bytes())
     }
 
-    fn encode_import(&mut self, id: ImportId, import: &Import) {
+    fn encode_import(
+        &mut self,
+        id: ImportId,
+        import: &ast::Import,
+        resolved_comp: &ResolvedComponent,
+    ) {
         let import_func_idx = id.index() as u32;
-        let import_name = import.name.as_ref().as_str();
+        let import_name = resolved_comp.component.get_name(import.ident);
 
+        let comp = &resolved_comp.component;
         match &import.external_type {
             ast::ExternalType::Function(fn_type) => {
                 // Encode Module Type and Import
-                self.encode_mod_import_type(fn_type);
+                self.encode_mod_import_type(fn_type, comp);
                 let module_ty = enc::EntityType::Function(import_func_idx);
                 self.module.imports.import("claw", import_name, module_ty);
 
                 // Encode Component Type and Import
-                self.encode_comp_import_type(fn_type);
+                self.encode_comp_import_type(fn_type, comp);
                 let component_ty = enc::ComponentTypeRef::Func(import_func_idx);
                 self.component.imports.import(import_name, component_ty);
 
@@ -93,16 +106,21 @@ impl CodeGenerator {
     }
 
     fn encode_globals(&mut self, component: &ResolvedComponent) {
+        let comp = &component.component;
+    
         for (id, global) in component.component.globals.iter() {
-            let valtype = global.valtype.as_ref();
-
             let global_type = enc::GlobalType {
-                mutable: global.mut_kwd.is_some(),
-                val_type: encode_valtype(valtype),
+                mutable: global.mutable,
+                val_type: global.type_id.with(comp).to_valtype(),
             };
 
             let init_expr = if let Some(init_value) = component.global_vals.get(&id) {
-                literal_to_constexpr(valtype, init_value)
+                let valtype = component.component.get_type(global.type_id);
+                match valtype {
+                    ast::ValType::Result { .. } => todo!(),
+                    ast::ValType::String => todo!(),
+                    ast::ValType::Primitive(p) => init_value.to_const_expr(*p),
+                }
             } else {
                 panic!("Cannot generate WASM for unresolved global")
             };
@@ -116,9 +134,10 @@ impl CodeGenerator {
         id: FunctionId,
         function: &ast::Function,
         resolved_comp: &ResolvedComponent,
-    ) {
+    ) -> Result<(), GenerationError> {
+        let comp = &resolved_comp.component;
         // Encode module and component type sections
-        self.encode_mod_func_type(&function.signature.fn_type);
+        self.encode_mod_func_type(&function.signature.fn_type, comp);
 
         let func_idx = resolved_comp.component.imports.len() + id.index();
         let func_idx = func_idx as u32;
@@ -128,42 +147,44 @@ impl CodeGenerator {
 
         // Encode module code
         let resolver = resolved_comp.resolved_funcs.get(&id).unwrap();
-        let locals = encode_locals(resolver);
+        let locals = encode_locals(resolver, resolved_comp);
         let mut builder = enc::Function::new(locals);
 
-        for statement in function.body.as_ref().statements.iter() {
-            encode_statement(
-                &resolved_comp,
-                resolver,
-                function,
-                statement.as_ref(),
-                &mut builder,
-            );
+        for statement in function.body.iter() {
+            encode_statement(&resolved_comp, *statement, id, &mut builder)?;
         }
-        builder.instruction(&enc::Instruction::End);
+        builder.instruction(&Instruction::End);
 
         self.module.code.function(&builder);
 
-        if function.export_kwd.is_some() {
-            self.encode_func_export(func_idx, function);
+        if function.exported {
+            self.encode_func_export(func_idx, function, resolved_comp);
         }
+        Ok(())
     }
 
-    fn encode_func_export(&mut self, func_idx: u32, function: &ast::Function) {
+    fn encode_func_export(
+        &mut self,
+        func_idx: u32,
+        function: &ast::Function,
+        resolved_comp: &ResolvedComponent,
+    ) {
+        let comp = &resolved_comp.component;
+        let ident = function.signature.ident;
+        let name = resolved_comp.component.get_name(ident);
+
         // Export function from module
-        self.module.exports.export(
-            function.signature.name.as_ref(),
-            enc::ExportKind::Func,
-            func_idx,
-        );
+        self.module
+            .exports
+            .export(name, enc::ExportKind::Func, func_idx);
         // Alias module instance export into component
         self.component.alias.alias(enc::Alias::CoreInstanceExport {
             instance: MODULE_INSTANCE_IDX,
             kind: enc::ExportKind::Func,
-            name: function.signature.name.as_ref(),
+            name,
         });
         // Encode component func type
-        self.encode_comp_func_type(&function.signature.fn_type);
+        self.encode_comp_func_type(&function.signature.fn_type, comp);
         // Lift aliased function to component function
         const NO_CANON_OPTS: [enc::CanonicalOption; 0] = [];
         self.component
@@ -171,7 +192,7 @@ impl CodeGenerator {
             .lift(func_idx, func_idx, NO_CANON_OPTS);
         // Export component function
         self.component.exports.export(
-            function.signature.name.as_ref(),
+            name,
             enc::ComponentExportKind::Func,
             func_idx,
             Some(enc::ComponentTypeRef::Func(func_idx)),
@@ -217,22 +238,24 @@ impl CodeGenerator {
         component.finish()
     }
 
-    fn encode_mod_import_type(&mut self, fn_type: &FnType) {
+    fn encode_mod_import_type(&mut self, fn_type: &ast::FnType, comp: &ast::Component) {
         let params = fn_type
             .arguments
             .iter()
-            .map(|(_name, valtype)| encode_valtype(valtype.as_ref()));
+            .map(|(_name, valtype)| valtype.with(comp).to_valtype());
 
-        let result_type = encode_valtype(fn_type.return_type.as_ref());
+        let result_type = fn_type.return_type.with(comp).to_valtype();
         self.module.types.function(params, [result_type]);
     }
 
-    fn encode_comp_import_type(&mut self, fn_type: &FnType) {
-        let params = fn_type
-            .arguments
-            .iter()
-            .map(|(name, valtype)| (name.as_ref().as_str(), encode_comp_valtype(valtype.as_ref())));
-        let result_type = encode_comp_valtype(fn_type.return_type.as_ref());
+    fn encode_comp_import_type(&mut self, fn_type: &ast::FnType, comp: &ast::Component) {
+        let params = fn_type.arguments.iter().map(|(name, type_id)| {
+            let name = comp.get_name(*name);
+            let valtype = comp.get_type(*type_id);
+            (name, valtype.with(comp).to_comp_valtype())
+        });
+        let valtype = comp.get_type(fn_type.return_type);
+        let result_type = valtype.with(comp).to_comp_valtype();
         self.component
             .types
             .function()
@@ -240,22 +263,24 @@ impl CodeGenerator {
             .result(result_type);
     }
 
-    fn encode_mod_func_type(&mut self, fn_type: &FnType) {
+    fn encode_mod_func_type(&mut self, fn_type: &ast::FnType, comp: &ast::Component) {
         let params = fn_type
             .arguments
             .iter()
-            .map(|(_name, valtype)| encode_valtype(valtype.as_ref()));
+            .map(|(_name, type_id)| type_id.with(comp).to_valtype());
 
-        let result_type = encode_valtype(fn_type.return_type.as_ref());
+        let result_type = fn_type.return_type.with(comp).to_valtype();
         self.module.types.function(params, [result_type]);
     }
 
-    fn encode_comp_func_type(&mut self, fn_type: &FnType) {
-        let params = fn_type
-            .arguments
-            .iter()
-            .map(|(name, valtype)| (name.as_ref().as_str(), encode_comp_valtype(valtype.as_ref())));
-        let result_type = encode_comp_valtype(fn_type.return_type.as_ref());
+    fn encode_comp_func_type(&mut self, fn_type: &ast::FnType, comp: &ast::Component) {
+        let params = fn_type.arguments.iter().map(|(name, type_id)| {
+            let name = comp.get_name(*name);
+            let valtype = comp.get_type(*type_id);
+            (name, valtype.with(comp).to_comp_valtype())
+        });
+        let valtype = comp.get_type(fn_type.return_type);
+        let result_type = valtype.with(comp).to_comp_valtype();
         self.component
             .types
             .function()
@@ -264,320 +289,501 @@ impl CodeGenerator {
     }
 }
 
-fn encode_locals(resolver: &FunctionResolver) -> Vec<(u32, enc::ValType)> {
+fn encode_locals(
+    resolver: &FunctionResolver,
+    resolved_comp: &ResolvedComponent,
+) -> Vec<(u32, enc::ValType)> {
     resolver
         .locals
         .iter()
         .map(|(id, _local)| {
-            let valtype = resolver.local_types.get(&id).unwrap();
-            (1, encode_valtype(&valtype))
+            let rtype = *resolver.local_types.get(&id).unwrap();
+            (1, rtype.with(&resolved_comp.component).to_valtype())
         })
         .collect()
 }
 
 fn encode_statement(
     component: &ResolvedComponent,
-    resolver: &FunctionResolver,
-    func: &ast::Function,
-    statement: &ast::Statement,
+    statement: StatementId,
+    func: FunctionId,
     builder: &mut enc::Function,
-) {
-    match statement {
-        ast::Statement::Let {
-            ident: _,
-            name_id,
-            expression,
-            ..
-        }
-        | ast::Statement::Assign {
-            ident: _,
-            name_id,
-            expression,
-            ..
-        } => {
-            encode_expression(resolver, func, *expression, builder);
-            match resolver.bindings.get(name_id).unwrap() {
+) -> Result<(), GenerationError> {
+    let resolver = component.resolved_funcs.get(&func).unwrap();
+
+    match component.component.get_statement(statement) {
+        ast::Statement::Let(ast::Let {
+            ident, expression, ..
+        })
+        | ast::Statement::Assign(ast::Assign {
+            ident, expression, ..
+        }) => {
+            encode_expression(component, *expression, func, builder)?;
+            match resolver.bindings.get(&ident).unwrap() {
                 ItemId::Import(_) => unimplemented!(),
                 ItemId::Global(global) => {
-                    builder.instruction(&enc::Instruction::GlobalSet(global.index() as u32));
+                    builder.instruction(&Instruction::GlobalSet(global.index() as u32));
                 }
                 ItemId::Param(param) => {
                     let local_index = param.index() as u32;
-                    builder.instruction(&enc::Instruction::LocalSet(local_index));
+                    builder.instruction(&Instruction::LocalSet(local_index));
                 }
                 ItemId::Local(local) => {
+                    let func = component.component.functions.get(func).unwrap();
                     let local_index = local.index() + func.signature.fn_type.arguments.len();
                     let local_index = local_index as u32;
-                    builder.instruction(&enc::Instruction::LocalSet(local_index));
+                    builder.instruction(&Instruction::LocalSet(local_index));
                 }
                 ItemId::Function(_) => unimplemented!(),
             }
         }
-        ast::Statement::Call { call } => {
+        ast::Statement::Call(call) => {
             for arg in call.args.iter() {
-                encode_expression(resolver, func, *arg, builder);
+                encode_expression(component, *arg, func, builder)?;
             }
-            let index = match resolver.bindings.get(&call.name_id).unwrap() {
+            let index = match resolver.bindings.get(&call.ident).unwrap() {
                 ItemId::Import(import) => import.index(),
                 ItemId::Function(function) => function.index(),
                 _ => panic!(""),
             };
-            builder.instruction(&enc::Instruction::Call(index as u32));
+            builder.instruction(&Instruction::Call(index as u32));
         }
-        ast::Statement::If {
-            if_kwd: _,
-            condition,
-            block,
-        } => {
-            encode_expression(resolver, func, *condition, builder);
-            builder.instruction(&enc::Instruction::If(enc::BlockType::Empty));
-            for statement in block.value.statements.iter() {
-                encode_statement(component, resolver, func, statement.as_ref(), builder);
+        ast::Statement::If(ast::If { condition, block }) => {
+            encode_expression(component, *condition, func, builder)?;
+            builder.instruction(&Instruction::If(enc::BlockType::Empty));
+            for statement in block.iter() {
+                encode_statement(component, *statement, func, builder)?;
             }
-            builder.instruction(&enc::Instruction::End);
+            builder.instruction(&Instruction::End);
         }
-        ast::Statement::Return {
-            return_kwd: _,
-            expression,
-        } => {
-            encode_expression(resolver, func, *expression, builder);
-            builder.instruction(&enc::Instruction::Return);
+        ast::Statement::Return(ast::Return { expression }) => {
+            encode_expression(component, *expression, func, builder)?;
+            builder.instruction(&Instruction::Return);
         }
     };
+    Ok(())
 }
 
+/// A simple helper that calls EncodeExpression::encode
 fn encode_expression(
-    resolver: &FunctionResolver,
-    func: &ast::Function,
+    component: &ResolvedComponent,
     expression: ExpressionId,
+    func: FunctionId,
     builder: &mut enc::Function,
-) {
-    match func.expressions.get_exp(expression) {
-        ast::Expression::Unary { .. } => {
-            todo!()
-        }
-
-        ast::Expression::Binary {
-            left,
-            operator,
-            right,
-        } => {
-            encode_expression(resolver, func, *left, builder);
-            encode_expression(resolver, func, *right, builder);
-
-            let inner_valtype = resolver.expression_types.get(left).unwrap();
-            encode_bin_op(operator.as_ref(), inner_valtype, builder);
-        }
-
-        ast::Expression::Call { call } => {
-            for arg in call.args.iter() {
-                encode_expression(resolver, func, *arg, builder);
-            }
-            let index = match resolver.bindings.get(&call.name_id).unwrap() {
-                ItemId::Import(import) => import.index(),
-                ItemId::Function(function) => function.index(),
-                _ => panic!(""),
-            };
-            builder.instruction(&enc::Instruction::Call(index as u32));
-        }
-
-        ast::Expression::Identifier { ident: _, name_id } => {
-            match resolver.bindings.get(name_id).unwrap() {
-                ItemId::Import(_) => unimplemented!(),
-                ItemId::Global(global) => {
-                    builder.instruction(&enc::Instruction::GlobalGet(global.index() as u32));
-                }
-                ItemId::Param(param) => {
-                    let local_index = param.index();
-                    builder.instruction(&enc::Instruction::LocalGet(local_index as u32));
-                }
-                ItemId::Local(local) => {
-                    let local_index = local.index() + func.signature.fn_type.arguments.len();
-                    builder.instruction(&enc::Instruction::LocalGet(local_index as u32));
-                }
-                ItemId::Function(_) => unimplemented!(),
-            }
-        }
-
-        ast::Expression::Literal { literal } => {
-            let valtype = resolver.expression_types.get(&expression).unwrap();
-            encode_literal_expr(builder, valtype, literal.as_ref());
-        }
-    }
+) -> Result<(), GenerationError> {
+    let expr = component.component.expr().get_exp(expression);
+    expr.encode(component, expression, func, builder)?;
+    Ok(())
 }
 
-fn encode_bin_op(bin_op: &BinaryOp, valtype: &ValType, builder: &mut enc::Function) {
-    let core_valtype = core_type_of(&valtype);
-    let signedness = signedness_of(&valtype);
-
-    let instruction = match (bin_op, core_valtype, signedness) {
-        // Multiply
-        (ast::BinaryOp::Mult, enc::ValType::I32, _) => enc::Instruction::I32Mul,
-        (ast::BinaryOp::Mult, enc::ValType::I64, _) => enc::Instruction::I64Mul,
-        (ast::BinaryOp::Mult, enc::ValType::F32, _) => enc::Instruction::F32Mul,
-        (ast::BinaryOp::Mult, enc::ValType::F64, _) => enc::Instruction::F64Mul,
-        (ast::BinaryOp::Mult, vtype, _) => panic!("Cannot multiply type {:?}", vtype),
-        // Divide
-        (ast::BinaryOp::Div, enc::ValType::I32, S) => enc::Instruction::I32DivS,
-        (ast::BinaryOp::Div, enc::ValType::I32, U) => enc::Instruction::I32DivU,
-        (ast::BinaryOp::Div, enc::ValType::I64, S) => enc::Instruction::I64DivS,
-        (ast::BinaryOp::Div, enc::ValType::I64, U) => enc::Instruction::I64DivU,
-        (ast::BinaryOp::Div, enc::ValType::F32, _) => enc::Instruction::F32Div,
-        (ast::BinaryOp::Div, enc::ValType::F64, _) => enc::Instruction::F64Div,
-        (ast::BinaryOp::Div, vtype, _) => panic!("Cannot divide type {:?}", vtype),
-        // Modulo
-        (ast::BinaryOp::Mod, _, _) => todo!(),
-        // Addition
-        (ast::BinaryOp::Add, enc::ValType::I32, _) => enc::Instruction::I32Add,
-        (ast::BinaryOp::Add, enc::ValType::I64, _) => enc::Instruction::I64Add,
-        (ast::BinaryOp::Add, enc::ValType::F32, _) => enc::Instruction::F32Add,
-        (ast::BinaryOp::Add, enc::ValType::F64, _) => enc::Instruction::F64Add,
-        // Subtraction
-        (ast::BinaryOp::Sub, enc::ValType::I32, _) => enc::Instruction::I32Sub,
-        (ast::BinaryOp::Sub, enc::ValType::I64, _) => enc::Instruction::I64Sub,
-        (ast::BinaryOp::Sub, enc::ValType::F32, _) => enc::Instruction::F32Sub,
-        (ast::BinaryOp::Sub, enc::ValType::F64, _) => enc::Instruction::F64Sub,
-        (ast::BinaryOp::BitShiftL, _, _) => todo!(),
-        (ast::BinaryOp::BitShiftR, _, _) => todo!(),
-        (ast::BinaryOp::ArithShiftR, _, _) => todo!(),
-        // Less than
-        (ast::BinaryOp::LT, enc::ValType::I32, S) => enc::Instruction::I32LtS,
-        (ast::BinaryOp::LT, enc::ValType::I32, U) => enc::Instruction::I32LtU,
-        (ast::BinaryOp::LT, enc::ValType::I64, S) => enc::Instruction::I64LtS,
-        (ast::BinaryOp::LT, enc::ValType::I64, U) => enc::Instruction::I64LtU,
-        (ast::BinaryOp::LT, enc::ValType::F32, _) => enc::Instruction::F32Lt,
-        (ast::BinaryOp::LT, enc::ValType::F64, _) => enc::Instruction::F64Lt,
-        // Less than equal
-        (ast::BinaryOp::LTE, enc::ValType::I32, S) => enc::Instruction::I32LeS,
-        (ast::BinaryOp::LTE, enc::ValType::I32, U) => enc::Instruction::I32LeU,
-        (ast::BinaryOp::LTE, enc::ValType::I64, S) => enc::Instruction::I64LeS,
-        (ast::BinaryOp::LTE, enc::ValType::I64, U) => enc::Instruction::I64LeU,
-        (ast::BinaryOp::LTE, enc::ValType::F32, _) => enc::Instruction::F32Le,
-        (ast::BinaryOp::LTE, enc::ValType::F64, _) => enc::Instruction::F64Le,
-        // Greater than
-        (ast::BinaryOp::GT, enc::ValType::I32, S) => enc::Instruction::I32GtS,
-        (ast::BinaryOp::GT, enc::ValType::I32, U) => enc::Instruction::I32GtU,
-        (ast::BinaryOp::GT, enc::ValType::I64, S) => enc::Instruction::I64GtS,
-        (ast::BinaryOp::GT, enc::ValType::I64, U) => enc::Instruction::I64GtU,
-        (ast::BinaryOp::GT, enc::ValType::F32, _) => enc::Instruction::F32Gt,
-        (ast::BinaryOp::GT, enc::ValType::F64, _) => enc::Instruction::F64Gt,
-        // Greater than or equal
-        (ast::BinaryOp::GTE, enc::ValType::I32, S) => enc::Instruction::I32GeS,
-        (ast::BinaryOp::GTE, enc::ValType::I32, U) => enc::Instruction::I32GeU,
-        (ast::BinaryOp::GTE, enc::ValType::I64, S) => enc::Instruction::I64GeS,
-        (ast::BinaryOp::GTE, enc::ValType::I64, U) => enc::Instruction::I64GeU,
-        (ast::BinaryOp::GTE, enc::ValType::F32, _) => enc::Instruction::F32Ge,
-        (ast::BinaryOp::GTE, enc::ValType::F64, _) => enc::Instruction::F64Ge,
-        // Equal
-        (ast::BinaryOp::EQ, enc::ValType::I32, _) => enc::Instruction::I32Eq,
-        (ast::BinaryOp::EQ, enc::ValType::I64, _) => enc::Instruction::I64Eq,
-        (ast::BinaryOp::EQ, enc::ValType::F32, _) => enc::Instruction::F32Eq,
-        (ast::BinaryOp::EQ, enc::ValType::F64, _) => enc::Instruction::F64Eq,
-        // Not equal
-        (ast::BinaryOp::NEQ, enc::ValType::I32, _) => enc::Instruction::I32Eq,
-        (ast::BinaryOp::NEQ, enc::ValType::I64, _) => enc::Instruction::I64Eq,
-        (ast::BinaryOp::NEQ, enc::ValType::F32, _) => enc::Instruction::F32Eq,
-        (ast::BinaryOp::NEQ, enc::ValType::F64, _) => enc::Instruction::F64Eq,
-        // Bitwise and
-        (ast::BinaryOp::BitAnd, _, _) => todo!(),
-        (ast::BinaryOp::BitXor, _, _) => todo!(),
-        (ast::BinaryOp::BitOr, _, _) => todo!(),
-        (ast::BinaryOp::LogicalAnd, _, _) => todo!(),
-        (ast::BinaryOp::LogicalOr, _, _) => todo!(),
-        _ => todo!()
-    };
-    builder.instruction(&instruction);
-}
-
-fn core_type_of(valtype: &ValType) -> enc::ValType {
-    match valtype {
-        ValType::U64 | ValType::S64 => enc::ValType::I64,
-
-        ValType::U32 | ValType::U16 | ValType::U8 | ValType::S32 | ValType::S16 | ValType::S8 => {
-            enc::ValType::I32
-        }
-
-        ValType::F32 => enc::ValType::F32,
-        ValType::F64 => enc::ValType::F64,
-
-        vtype => unimplemented!("Core type of {:?}", vtype),
-    }
-}
-
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 enum Signedness {
     Unsigned,
     Signed,
-    NotApplicable
+    NotApplicable,
 }
 
 const S: Signedness = Signedness::Signed;
 const U: Signedness = Signedness::Unsigned;
 
-fn signedness_of(valtype: &ValType) -> Signedness {
-    match valtype {
-        ValType::U64 | ValType::U32 | ValType::U16 | ValType::U8 => Signedness::Unsigned,
-        ValType::S64 | ValType::S32 | ValType::S16 | ValType::S8 => Signedness::Signed,
-        _ => Signedness::NotApplicable,
+impl ast::PrimitiveType {
+    fn core_type(&self) -> enc::ValType {
+        use ast::PrimitiveType;
+
+        match self {
+            PrimitiveType::Bool => enc::ValType::I32,
+
+            PrimitiveType::U64 | PrimitiveType::S64 => enc::ValType::I64,
+
+            PrimitiveType::U32
+            | PrimitiveType::U16
+            | PrimitiveType::U8
+            | PrimitiveType::S32
+            | PrimitiveType::S16
+            | PrimitiveType::S8 => enc::ValType::I32,
+
+            PrimitiveType::F32 => enc::ValType::F32,
+            PrimitiveType::F64 => enc::ValType::F64,
+        }
+    }
+
+    fn signedness(&self) -> Signedness {
+        use ast::PrimitiveType;
+
+        match self {
+            PrimitiveType::U64 | PrimitiveType::U32 | PrimitiveType::U16 | PrimitiveType::U8 => {
+                Signedness::Unsigned
+            }
+            PrimitiveType::S64 | PrimitiveType::S32 | PrimitiveType::S16 | PrimitiveType::S8 => {
+                Signedness::Signed
+            }
+            _ => Signedness::NotApplicable,
+        }
     }
 }
 
-fn encode_literal_expr(builder: &mut enc::Function, valtype: &ValType, literal: &Literal) {
-    let instruction = match (valtype, &literal) {
-        (ValType::S32 | ValType::U32, Literal::Integer(value)) => {
-            enc::Instruction::I32Const(*value as i32)
-        }
-        (ValType::S64 | ValType::U64, Literal::Integer(value)) => {
-            enc::Instruction::I64Const(*value as i64)
-        }
-        (ValType::F32, Literal::Float(value)) => enc::Instruction::F32Const(*value as f32),
-        (ValType::F64, Literal::Float(value)) => enc::Instruction::F64Const(*value),
-        _ => todo!(),
-    };
-    builder.instruction(&instruction);
-}
+// Literal
 
-fn literal_to_constexpr(valtype: &ValType, literal: &Literal) -> enc::ConstExpr {
-    match (valtype, &literal) {
-        (ValType::S32 | ValType::U32, Literal::Integer(value)) => {
-            enc::ConstExpr::i32_const(*value as i32)
+impl ast::Literal {
+    fn to_const_expr(&self, ptype: ast::PrimitiveType) -> enc::ConstExpr {
+        use ast::{Literal, PrimitiveType};
+        match (ptype, self) {
+            (PrimitiveType::S32 | PrimitiveType::U32, Literal::Integer(value)) => {
+                enc::ConstExpr::i32_const(*value as i32)
+            }
+            (PrimitiveType::S64 | PrimitiveType::U64, Literal::Integer(value)) => {
+                enc::ConstExpr::i64_const(*value as i64)
+            }
+            (PrimitiveType::F32, Literal::Float(value)) => enc::ConstExpr::f32_const(*value as f32),
+            (PrimitiveType::F64, Literal::Float(value)) => enc::ConstExpr::f64_const(*value),
+            _ => todo!(),
         }
-        (ValType::S64 | ValType::U64, Literal::Integer(value)) => {
-            enc::ConstExpr::i64_const(*value as i64)
-        }
-        (ValType::F32, Literal::Float(value)) => enc::ConstExpr::f32_const(*value as f32),
-        (ValType::F64, Literal::Float(value)) => enc::ConstExpr::f64_const(*value),
-        _ => todo!(),
     }
 }
 
-fn encode_valtype(valtype: &ValType) -> enc::ValType {
-    match valtype {
-        ValType::U32 | ValType::S32 => enc::ValType::I32,
-        ValType::U64 | ValType::S64 => enc::ValType::I64,
-        ValType::F32 => enc::ValType::F32,
-        ValType::F64 => enc::ValType::F64,
-        ValType::Bool => enc::ValType::I32,
-        _ => panic!("Unsupported type for WAT output {:?}", valtype),
+// ResolvedType
+
+#[allow(dead_code)]
+impl<'ctx> C<'ctx, ResolvedType, ast::Component> {
+    fn to_valtype(&self) -> enc::ValType {
+        match self.value {
+            ResolvedType::Primitive(p) => p.to_valtype(),
+            ResolvedType::ValType(type_id) => type_id.with(self.context).to_valtype(),
+        }
+    }
+
+    fn to_comp_valtype(&self) -> enc::ComponentValType {
+        match self.value {
+            ResolvedType::Primitive(p) => p.to_comp_valtype(),
+            ResolvedType::ValType(t) => t.with(self.context).to_comp_valtype(),
+        }
     }
 }
 
-fn encode_comp_valtype(valtype: &ValType) -> enc::ComponentValType {
-    use enc::PrimitiveValType;
-    let primitive = match valtype {
-        ValType::Result { ok: _, err: _ } => todo!(),
-        ValType::String => PrimitiveValType::String,
-        ValType::U64 => PrimitiveValType::U64,
-        ValType::U32 => PrimitiveValType::U32,
-        ValType::U16 => PrimitiveValType::U16,
-        ValType::U8 => PrimitiveValType::U8,
-        ValType::S64 => PrimitiveValType::S64,
-        ValType::S32 => PrimitiveValType::S32,
-        ValType::S16 => PrimitiveValType::S16,
-        ValType::S8 => PrimitiveValType::S8,
-        ValType::F32 => PrimitiveValType::Float32,
-        ValType::F64 => PrimitiveValType::Float64,
-        ValType::Bool => PrimitiveValType::Bool,
-    };
-    enc::ComponentValType::Primitive(primitive)
+// TypeId
+
+#[allow(dead_code)]
+impl<'ctx> C<'ctx, TypeId, ast::Component> {
+    fn to_valtype(&self) -> enc::ValType {
+        let valtype = self.context.get_type(*self.value);
+        valtype.with(self.context).to_valtype()
+    }
+
+    fn to_comp_valtype(&self) -> enc::ComponentValType {
+        let valtype = self.context.get_type(*self.value);
+        valtype.with(self.context).to_comp_valtype()
+    }
+}
+
+// ast::ValType
+
+impl<'ctx> C<'ctx, ast::ValType, ast::Component> {
+    fn to_valtype(&self) -> enc::ValType {
+        match self.value {
+            ast::ValType::Primitive(p) => p.to_valtype(),
+            _ => panic!("Cannot encode non-primitive as a valtype"),
+        }
+    }
+
+    fn to_comp_valtype(&self) -> enc::ComponentValType {
+        match self.value {
+            ast::ValType::Result { .. } => todo!(),
+            ast::ValType::String => todo!(),
+            ast::ValType::Primitive(p) => p.to_comp_valtype(),
+        }
+    }
+}
+
+// PrimitiveType
+
+impl ast::PrimitiveType {
+    fn to_valtype(&self) -> enc::ValType {
+        use ast::PrimitiveType;
+        match self {
+            PrimitiveType::U32
+            | PrimitiveType::S32
+            | PrimitiveType::U16
+            | PrimitiveType::S16
+            | PrimitiveType::U8
+            | PrimitiveType::S8
+            | PrimitiveType::Bool => enc::ValType::I32,
+
+            PrimitiveType::U64 | PrimitiveType::S64 => enc::ValType::I64,
+
+            PrimitiveType::F32 => enc::ValType::F32,
+            PrimitiveType::F64 => enc::ValType::F64,
+        }
+    }
+
+    fn to_primitive_valtype(&self) -> enc::PrimitiveValType {
+        use ast::PrimitiveType;
+        match self {
+            PrimitiveType::U64 => enc::PrimitiveValType::U64,
+            PrimitiveType::U32 => enc::PrimitiveValType::U32,
+            PrimitiveType::U16 => enc::PrimitiveValType::U16,
+            PrimitiveType::U8 => enc::PrimitiveValType::U8,
+            PrimitiveType::S64 => enc::PrimitiveValType::S64,
+            PrimitiveType::S32 => enc::PrimitiveValType::S32,
+            PrimitiveType::S16 => enc::PrimitiveValType::S16,
+            PrimitiveType::S8 => enc::PrimitiveValType::S8,
+            PrimitiveType::F32 => enc::PrimitiveValType::Float32,
+            PrimitiveType::F64 => enc::PrimitiveValType::Float64,
+            PrimitiveType::Bool => enc::PrimitiveValType::Bool,
+        }
+    }
+
+    fn to_comp_valtype(&self) -> enc::ComponentValType {
+        enc::ComponentValType::Primitive(self.to_primitive_valtype())
+    }
+}
+
+// ValType
+
+#[allow(dead_code)]
+impl ast::ValType {
+    fn to_comp_valtype(&self) -> enc::ComponentValType {
+        match self {
+            ast::ValType::Result { .. } => todo!(),
+            ast::ValType::String => todo!(),
+            ast::ValType::Primitive(p) => p.to_comp_valtype(),
+        }
+    }
+}
+
+//
+
+trait EncodeExpression {
+    fn encode(
+        &self,
+        component: &ResolvedComponent,
+        expression: ExpressionId,
+        func: FunctionId,
+        builder: &mut enc::Function,
+    ) -> Result<(), GenerationError>;
+}
+
+impl EncodeExpression for ast::Expression {
+    fn encode(
+        &self,
+        component: &ResolvedComponent,
+        expression: ExpressionId,
+        func: FunctionId,
+        builder: &mut enc::Function,
+    ) -> Result<(), GenerationError> {
+        let expr: &dyn EncodeExpression = match self {
+            ast::Expression::Identifier(expr) => expr,
+            ast::Expression::Literal(expr) => expr,
+            ast::Expression::Call(expr) => expr,
+            ast::Expression::Unary(expr) => expr,
+            ast::Expression::Binary(expr) => expr,
+        };
+        expr.encode(component, expression, func, builder)?;
+        Ok(())
+    }
+}
+
+impl EncodeExpression for ast::Identifier {
+    fn encode(
+        &self,
+        component: &ResolvedComponent,
+        _expression: ExpressionId,
+        func: FunctionId,
+        builder: &mut enc::Function,
+    ) -> Result<(), GenerationError> {
+        let resolver = component.resolved_funcs.get(&func).unwrap();
+        match resolver.bindings.get(&self.ident).unwrap() {
+            ItemId::Import(_) => unimplemented!(),
+            ItemId::Global(global) => {
+                builder.instruction(&Instruction::GlobalGet(global.index() as u32));
+            }
+            ItemId::Param(param) => {
+                let local_index = param.index();
+                builder.instruction(&Instruction::LocalGet(local_index as u32));
+            }
+            ItemId::Local(local) => {
+                let func = component.component.functions.get(func).unwrap();
+                let local_index = local.index() + func.signature.fn_type.arguments.len();
+                builder.instruction(&Instruction::LocalGet(local_index as u32));
+            }
+            ItemId::Function(_) => unimplemented!(),
+        }
+        Ok(())
+    }
+}
+
+impl EncodeExpression for ast::Literal {
+    fn encode(
+        &self,
+        component: &ResolvedComponent,
+        expression: ExpressionId,
+        func: FunctionId,
+        builder: &mut enc::Function,
+    ) -> Result<(), GenerationError> {
+        let comp = &component.component;
+        let resolver = component.resolved_funcs.get(&func).unwrap();
+
+        let rtype = resolver.get_resolved_type(expression, comp)?;
+        let valtype = rtype.with(comp).to_valtype();
+
+        use ast::Literal;
+        let instruction = match (valtype, self) {
+            (enc::ValType::I32, Literal::Integer(value)) => Instruction::I32Const(*value as i32),
+            (enc::ValType::I64, Literal::Integer(value)) => Instruction::I64Const(*value as i64),
+            (enc::ValType::F32, Literal::Float(value)) => Instruction::F32Const(*value as f32),
+            (enc::ValType::F64, Literal::Float(value)) => Instruction::F64Const(*value),
+            _ => todo!(),
+        };
+        builder.instruction(&instruction);
+        Ok(())
+    }
+}
+
+impl EncodeExpression for ast::Call {
+    fn encode(
+        &self,
+        component: &ResolvedComponent,
+        _expression: ExpressionId,
+        func: FunctionId,
+        builder: &mut enc::Function,
+    ) -> Result<(), GenerationError> {
+        for arg in self.args.iter() {
+            encode_expression(component, *arg, func, builder)?;
+        }
+        let resolver = component.resolved_funcs.get(&func).unwrap();
+        let index = match resolver.bindings.get(&self.ident).unwrap() {
+            ItemId::Import(import) => import.index(),
+            ItemId::Function(function) => function.index(),
+            _ => panic!(""),
+        };
+        builder.instruction(&Instruction::Call(index as u32));
+        Ok(())
+    }
+}
+
+impl EncodeExpression for ast::UnaryExpression {
+    fn encode(
+        &self,
+        component: &ResolvedComponent,
+        expression: ExpressionId,
+        func: FunctionId,
+        builder: &mut enc::Function,
+    ) -> Result<(), GenerationError> {
+        _ = (component, expression, func, builder);
+        todo!()
+    }
+}
+
+
+impl EncodeExpression for ast::BinaryExpression {
+    fn encode(
+        &self,
+        component: &ResolvedComponent,
+        _expression: ExpressionId,
+        func: FunctionId,
+        builder: &mut enc::Function,
+    ) -> Result<(), GenerationError> {
+        let comp = &component.component;
+        encode_expression(component, self.left, func, builder)?;
+        encode_expression(component, self.right, func, builder)?;
+
+        let resolver = component.resolved_funcs.get(&func).unwrap();
+        let rtype = resolver.get_resolved_type(self.left, comp)?;
+
+        let p = rtype.with(&component.component).as_primitive().unwrap();
+
+        let instruction = match (self.op, p.core_type(), p.signedness()) {
+            // Multiply
+            (ast::BinaryOp::Multiply, enc::ValType::I32, _) => enc::Instruction::I32Mul,
+            (ast::BinaryOp::Multiply, enc::ValType::I64, _) => enc::Instruction::I64Mul,
+            (ast::BinaryOp::Multiply, enc::ValType::F32, _) => enc::Instruction::F32Mul,
+            (ast::BinaryOp::Multiply, enc::ValType::F64, _) => enc::Instruction::F64Mul,
+            // Divide
+            (ast::BinaryOp::Divide, enc::ValType::I32, S) => enc::Instruction::I32DivS,
+            (ast::BinaryOp::Divide, enc::ValType::I32, U) => enc::Instruction::I32DivU,
+            (ast::BinaryOp::Divide, enc::ValType::I64, S) => enc::Instruction::I64DivS,
+            (ast::BinaryOp::Divide, enc::ValType::I64, U) => enc::Instruction::I64DivU,
+            (ast::BinaryOp::Divide, enc::ValType::F32, _) => enc::Instruction::F32Div,
+            (ast::BinaryOp::Divide, enc::ValType::F64, _) => enc::Instruction::F64Div,
+            // Modulo
+            (ast::BinaryOp::Modulo, enc::ValType::I32, S) => enc::Instruction::I32RemS,
+            (ast::BinaryOp::Modulo, enc::ValType::I32, U) => enc::Instruction::I32RemU,
+            (ast::BinaryOp::Modulo, enc::ValType::I64, S) => enc::Instruction::I64RemS,
+            (ast::BinaryOp::Modulo, enc::ValType::I64, U) => enc::Instruction::I64RemU,
+            // Addition
+            (ast::BinaryOp::Add, enc::ValType::I32, _) => enc::Instruction::I32Add,
+            (ast::BinaryOp::Add, enc::ValType::I64, _) => enc::Instruction::I64Add,
+            (ast::BinaryOp::Add, enc::ValType::F32, _) => enc::Instruction::F32Add,
+            (ast::BinaryOp::Add, enc::ValType::F64, _) => enc::Instruction::F64Add,
+            // Subtraction
+            (ast::BinaryOp::Subtract, enc::ValType::I32, _) => enc::Instruction::I32Sub,
+            (ast::BinaryOp::Subtract, enc::ValType::I64, _) => enc::Instruction::I64Sub,
+            (ast::BinaryOp::Subtract, enc::ValType::F32, _) => enc::Instruction::F32Sub,
+            (ast::BinaryOp::Subtract, enc::ValType::F64, _) => enc::Instruction::F64Sub,
+            // Logical Bit Shifting
+            (ast::BinaryOp::BitShiftL, enc::ValType::I32, _) => enc::Instruction::I32Shl,
+            (ast::BinaryOp::BitShiftL, enc::ValType::I64, _) => enc::Instruction::I64Shl,
+            (ast::BinaryOp::BitShiftR, enc::ValType::I32, _) => enc::Instruction::I32ShrU,
+            (ast::BinaryOp::BitShiftR, enc::ValType::I64, _) => enc::Instruction::I64ShrU,
+            // Arithmetic Bit Shifting
+            (ast::BinaryOp::ArithShiftR, enc::ValType::I32, S) => enc::Instruction::I32ShrS,
+            (ast::BinaryOp::ArithShiftR, enc::ValType::I32, U) => enc::Instruction::I32ShrU,
+            (ast::BinaryOp::ArithShiftR, enc::ValType::I64, S) => enc::Instruction::I64ShrS,
+            (ast::BinaryOp::ArithShiftR, enc::ValType::I64, U) => enc::Instruction::I64ShrU,
+            // Less than
+            (ast::BinaryOp::LessThan, enc::ValType::I32, S) => enc::Instruction::I32LtS,
+            (ast::BinaryOp::LessThan, enc::ValType::I32, U) => enc::Instruction::I32LtU,
+            (ast::BinaryOp::LessThan, enc::ValType::I64, S) => enc::Instruction::I64LtS,
+            (ast::BinaryOp::LessThan, enc::ValType::I64, U) => enc::Instruction::I64LtU,
+            (ast::BinaryOp::LessThan, enc::ValType::F32, _) => enc::Instruction::F32Lt,
+            (ast::BinaryOp::LessThan, enc::ValType::F64, _) => enc::Instruction::F64Lt,
+            (ast::BinaryOp::LessThan, valtype, s) => panic!("Failed to encode '<' for type {:?} and signedness {:?}", valtype, s),
+            // Less than equal
+            (ast::BinaryOp::LessThanEqual, enc::ValType::I32, S) => enc::Instruction::I32LeS,
+            (ast::BinaryOp::LessThanEqual, enc::ValType::I32, U) => enc::Instruction::I32LeU,
+            (ast::BinaryOp::LessThanEqual, enc::ValType::I64, S) => enc::Instruction::I64LeS,
+            (ast::BinaryOp::LessThanEqual, enc::ValType::I64, U) => enc::Instruction::I64LeU,
+            (ast::BinaryOp::LessThanEqual, enc::ValType::F32, _) => enc::Instruction::F32Le,
+            (ast::BinaryOp::LessThanEqual, enc::ValType::F64, _) => enc::Instruction::F64Le,
+            // Greater than
+            (ast::BinaryOp::GreaterThan, enc::ValType::I32, S) => enc::Instruction::I32GtS,
+            (ast::BinaryOp::GreaterThan, enc::ValType::I32, U) => enc::Instruction::I32GtU,
+            (ast::BinaryOp::GreaterThan, enc::ValType::I64, S) => enc::Instruction::I64GtS,
+            (ast::BinaryOp::GreaterThan, enc::ValType::I64, U) => enc::Instruction::I64GtU,
+            (ast::BinaryOp::GreaterThan, enc::ValType::F32, _) => enc::Instruction::F32Gt,
+            (ast::BinaryOp::GreaterThan, enc::ValType::F64, _) => enc::Instruction::F64Gt,
+            // Greater than or equal
+            (ast::BinaryOp::GreaterThanEqual, enc::ValType::I32, S) => enc::Instruction::I32GeS,
+            (ast::BinaryOp::GreaterThanEqual, enc::ValType::I32, U) => enc::Instruction::I32GeU,
+            (ast::BinaryOp::GreaterThanEqual, enc::ValType::I64, S) => enc::Instruction::I64GeS,
+            (ast::BinaryOp::GreaterThanEqual, enc::ValType::I64, U) => enc::Instruction::I64GeU,
+            (ast::BinaryOp::GreaterThanEqual, enc::ValType::F32, _) => enc::Instruction::F32Ge,
+            (ast::BinaryOp::GreaterThanEqual, enc::ValType::F64, _) => enc::Instruction::F64Ge,
+            // Equal
+            (ast::BinaryOp::Equals, enc::ValType::I32, _) => enc::Instruction::I32Eq,
+            (ast::BinaryOp::Equals, enc::ValType::I64, _) => enc::Instruction::I64Eq,
+            (ast::BinaryOp::Equals, enc::ValType::F32, _) => enc::Instruction::F32Eq,
+            (ast::BinaryOp::Equals, enc::ValType::F64, _) => enc::Instruction::F64Eq,
+            // Not equal
+            (ast::BinaryOp::NotEquals, enc::ValType::I32, _) => enc::Instruction::I32Eq,
+            (ast::BinaryOp::NotEquals, enc::ValType::I64, _) => enc::Instruction::I64Eq,
+            (ast::BinaryOp::NotEquals, enc::ValType::F32, _) => enc::Instruction::F32Eq,
+            (ast::BinaryOp::NotEquals, enc::ValType::F64, _) => enc::Instruction::F64Eq,
+            // Bitwise and
+            (ast::BinaryOp::BitAnd, enc::ValType::I32, _) => enc::Instruction::I32And,
+            (ast::BinaryOp::BitAnd, enc::ValType::I64, _) => enc::Instruction::I64And,
+            // Bitwise xor
+            (ast::BinaryOp::BitXor, enc::ValType::I32, _) => enc::Instruction::I32Xor,
+            (ast::BinaryOp::BitXor, enc::ValType::I64, _) => enc::Instruction::I64Xor,
+            // Bitwise or
+            (ast::BinaryOp::BitOr, enc::ValType::I32, _) => enc::Instruction::I32Or,
+            (ast::BinaryOp::BitOr, enc::ValType::I64, _) => enc::Instruction::I64Or,
+            // Logical and/or
+            (ast::BinaryOp::LogicalAnd, enc::ValType::I32, _) => enc::Instruction::I32And,
+            (ast::BinaryOp::LogicalOr, enc::ValType::I32, _) => enc::Instruction::I32Or,
+            // Fallback
+            (operator, valtype, _) => panic!("Cannot apply binary operator {:?} to type {:?}", operator, valtype)
+        };
+        builder.instruction(&instruction);
+        Ok(())
+    }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,20 @@
+pub struct C<'ctx, T, Context> {
+    pub value: &'ctx T,
+    pub context: &'ctx Context
+}
+
+pub trait WithContext<Context>
+where
+    Self: Sized
+{
+    fn with<'ctx>(&'ctx self, context: &'ctx Context) -> C<'ctx, Self, Context> {
+        C {
+            value: self,
+            context
+        }
+    }
+}
+
+impl<T, Context> WithContext<Context> for T {}
+
+

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use logos::Logos;
 
-use miette::{Diagnostic, NamedSource, SourceSpan};
+use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -16,18 +14,19 @@ pub struct TokenData {
 #[diagnostic()]
 pub struct LexerError {
     #[source_code]
-    src: Arc<NamedSource>,
+    src: crate::Source,
     #[label("This text was not recognized")]
     span: SourceSpan,
 }
 
 pub fn tokenize<'src>(
-    src: Arc<NamedSource>,
+    src: crate::Source,
     contents: &'src str,
 ) -> Result<Vec<TokenData>, LexerError> {
     let lexer = Token::lexer(&contents);
 
-    lexer.spanned()
+    lexer
+        .spanned()
         .map(|(token, span)| match token {
             Ok(token) => Ok(TokenData {
                 token,
@@ -512,7 +511,7 @@ mod test {
     #[test]
     fn tokenize_func_declaration() {
         let contents = "func test(a: u32) -> u32";
-        let src = Arc::new(NamedSource::new(String::from("test"), contents));
+        let src = crate::make_source("test", contents);
         let ident_test = Token::Identifier("test".to_owned());
         let ident_a = Token::Identifier("a".to_owned());
         let output = vec![
@@ -539,7 +538,7 @@ mod test {
     #[test]
     fn tokenize_let() {
         let contents = r#"let a = "asdf\"";"#;
-        let src = Arc::new(NamedSource::new(String::from("test"), contents));
+        let src = crate::make_source("test", contents);
         let ident_a = Token::Identifier("a".to_owned());
         let string_asdf = Token::StringLiteral(String::from(r#"asdf""#));
         let output = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,23 +8,24 @@ pub mod codegen;
 pub mod lexer;
 pub mod parser;
 pub mod resolver;
+pub mod context;
 
 pub mod stack_map;
 
-pub fn compile<'src>(
-    source_name: String,
-    source_code: &'src str,
-) -> Option<ResolvedComponent> {
-    let src = Arc::new(NamedSource::new(
-        source_name,
-        Box::leak(source_code.to_owned().into_boxed_str()) as &'static str,
-    ));
+pub type Source = Arc<NamedSource<String>>;
+
+pub fn make_source(name: &str, source: &str) -> Source {
+    Arc::new(NamedSource::new(name.to_owned(), source.to_owned()))
+}
+
+pub fn compile<'src>(source_name: String, source_code: &'src str) -> Option<ResolvedComponent> {
+    let src = make_source(source_name.as_str(), source_code);
 
     let tokens = match lexer::tokenize(src.clone(), source_code) {
         Ok(token_data) => token_data,
         Err(error) => {
-           println!("{:?}", Report::new(error));
-           return None;
+            println!("{:?}", Report::new(error));
+            return None;
         }
     };
 

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -1,170 +1,137 @@
-use crate::ast::expressions::ExpressionData;
-use crate::ast::NameId;
-use crate::ast::{
-    component::{Block, Statement},
-    M,
-};
+use crate::ast::{self, Span, merge, NameId, StatementId, Component};
 use crate::lexer::Token;
-use crate::parser::{
-    expressions::{parse_expression, parse_ident},
-    types::parse_valtype,
-    ParseInput, ParserError,
-};
+use crate::parser::{expressions::parse_expression, types::parse_valtype, ParseInput, ParserError};
 
 pub fn parse_block(
     input: &mut ParseInput,
-    data: &mut ExpressionData,
-) -> Result<M<Block>, ParserError> {
-    let start_brace = input.assert_next(Token::LBrace, "Left brace '{'")?;
-    let start_span = start_brace.clone();
+    comp: &mut Component,
+) -> Result<(Vec<StatementId>, Span), ParserError> {
+    let start_span = input.assert_next(Token::LBrace, "Left brace '{'")?;
 
     let mut statements = Vec::new();
     while input.peek()?.token != Token::RBrace {
-        statements.push(parse_statement(input, data)?);
+        statements.push(parse_statement(input, comp)?);
     }
 
-    let end_brace = input.assert_next(Token::RBrace, "Right brace '}'")?;
-    let end_span = end_brace.clone();
-    Ok(M::new_range(
-        Block {
-            start_brace,
-            statements,
-            end_brace,
-        },
-        start_span,
-        end_span,
-    ))
+    let end_span = input.assert_next(Token::RBrace, "Right brace '}'")?;
+
+    let span = merge(&start_span, &end_span);
+    Ok((statements, span))
+}
+
+/// Parse an identifier
+pub fn parse_ident(input: &mut ParseInput, comp: &mut Component) -> Result<NameId, ParserError> {
+    let checkpoint = input.checkpoint();
+    let next = input.next()?;
+    let span = next.span.clone();
+    match next.token.clone() {
+        Token::Identifier(ident) => Ok(comp.new_name(ident, span)),
+        _ => {
+            input.restore(checkpoint);
+            Err(input.unexpected_token("Expected identifier"))
+        }
+    }
 }
 
 pub fn parse_statement(
     input: &mut ParseInput,
-    data: &mut ExpressionData,
-) -> Result<M<Statement>, ParserError> {
+    comp: &mut Component,
+) -> Result<StatementId, ParserError> {
     return match input.peek()?.token {
-        Token::Return => parse_return(input, data),
-        Token::Let => parse_let(input, data),
-        Token::If => parse_if(input, data),
-        _ => parse_assign(input, data),
+        Token::Return => parse_return(input, comp),
+        Token::Let => parse_let(input, comp),
+        Token::If => parse_if(input, comp),
+        _ => parse_assign(input, comp),
     };
 }
 
-fn parse_let(
-    input: &mut ParseInput,
-    data: &mut ExpressionData,
-) -> Result<M<Statement>, ParserError> {
+fn parse_let(input: &mut ParseInput, comp: &mut Component) -> Result<StatementId, ParserError> {
     // Prefix
-    let let_kwd = input.assert_next(Token::Let, "Let keyword 'let'")?;
-    let start_span = let_kwd.clone();
-    let mut_kwd = input.next_if(Token::Mut);
-    let ident = parse_ident(input)?;
+    let start_span = input.assert_next(Token::Let, "Let keyword 'let'")?;
+    let mutable = input.next_if(Token::Mut).is_some();
+    let ident = parse_ident(input, comp)?;
 
     // Annotation
     let annotation = match input.next_if(Token::Colon) {
-        Some(_) => Some(parse_valtype(input)?),
+        Some(_) => Some(parse_valtype(input, comp)?),
         None => None,
     };
 
     // Suffix
-    let assign_op = input.assert_next(Token::Assign, "Assignment '='")?;
-    let expression = parse_expression(input, data)?;
-    let semicolon = input.assert_next(Token::Semicolon, "Semicolon ';'")?;
+    input.assert_next(Token::Assign, "Assignment '='")?;
+    let expression = parse_expression(input, comp)?;
+    let end_span = input.assert_next(Token::Semicolon, "Semicolon ';'")?;
 
-    let statement = Statement::Let {
-        let_kwd,
-        mut_kwd,
-        ident,
-        name_id: NameId::new(),
-        annotation,
-        assign_op,
-        expression,
-    };
-    Ok(M::new_range(statement, start_span, semicolon))
+    let span = merge(&start_span, &end_span);
+    Ok(comp.alloc_let(mutable, ident, annotation, expression, span))
 }
 
-fn parse_return(
-    input: &mut ParseInput,
-    data: &mut ExpressionData,
-) -> Result<M<Statement>, ParserError> {
-    let return_kwd = input.assert_next(Token::Return, "Return keyword 'return'")?;
-    let expression = parse_expression(input, data)?;
-    let semicolon = input.assert_next(Token::Semicolon, "Semicolon ';'")?;
+fn parse_return(input: &mut ParseInput, comp: &mut Component) -> Result<StatementId, ParserError> {
+    let start_span = input.assert_next(Token::Return, "Return keyword 'return'")?;
+    let expression = parse_expression(input, comp)?;
+    let end_span = input.assert_next(Token::Semicolon, "Semicolon ';'")?;
 
-    let span = return_kwd.clone();
-    let statement = Statement::Return {
-        return_kwd,
-        expression,
-    };
-    Ok(M::new_range(statement, span, semicolon))
+    let statement = ast::Return { expression };
+    let span = merge(&start_span, &end_span);
+    Ok(comp.new_statement(ast::Statement::Return(statement), span))
 }
 
-fn parse_assign(
-    input: &mut ParseInput,
-    data: &mut ExpressionData,
-) -> Result<M<Statement>, ParserError> {
-    let ident = parse_ident(input)?;
-    let assign_op = input.assert_next(Token::Assign, "Assign '='")?;
-    let expression = parse_expression(input, data)?;
-    let semicolon = input.assert_next(Token::Semicolon, "Semicolon ';'")?;
+fn parse_assign(input: &mut ParseInput, comp: &mut Component) -> Result<StatementId, ParserError> {
+    let ident = parse_ident(input, comp)?;
+    let start_span = comp.name_span(ident);
+    input.assert_next(Token::Assign, "Assign '='")?;
+    let expression = parse_expression(input, comp)?;
+    let end_span = input.assert_next(Token::Semicolon, "Semicolon ';'")?;
 
-    let span = ident.span.clone();
-    let statement = Statement::Assign {
-        ident,
-        name_id: NameId::new(),
-        assign_op,
-        expression,
-    };
-    Ok(M::new_range(statement, span, semicolon))
+    let statement = ast::Assign { ident, expression };
+    let span = merge(&start_span, &end_span);
+    Ok(comp.new_statement(ast::Statement::Assign(statement), span))
 }
 
-fn parse_if(
-    input: &mut ParseInput,
-    data: &mut ExpressionData,
-) -> Result<M<Statement>, ParserError> {
-    let if_kwd = input.assert_next(Token::If, "If keyword 'if'")?;
-    let condition = parse_expression(input, data)?;
-    let block = parse_block(input, data)?;
+fn parse_if(input: &mut ParseInput, comp: &mut Component) -> Result<StatementId, ParserError> {
+    let start_span = input.assert_next(Token::If, "If keyword 'if'")?;
+    let condition = parse_expression(input, comp)?;
+    let (block, end_span) = parse_block(input, comp)?;
 
-    let start_span = if_kwd.clone();
-    let end_span = block.span.clone();
-
-    let statement = Statement::If {
-        if_kwd,
-        condition,
-        block,
-    };
-    Ok(M::new_range(statement, start_span, end_span))
+    let statement = ast::If { condition, block };
+    let span = merge(&start_span, &end_span);
+    Ok(comp.new_statement(ast::Statement::If(statement), span))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::tests::make_input;
+    use crate::parser::make_input;
 
     #[test]
     fn test_parse_block_empty() {
-        let mut data = ExpressionData::default();
         let source = "{}";
-        let _assign_stmt = parse_block(&mut make_input(source), &mut data).unwrap();
+        let (src, mut input) = make_input(source);
+        let mut comp = Component::new(src);
+        let _assign_stmt = parse_block(&mut input, &mut comp).unwrap();
     }
 
     #[test]
     fn test_parse_block() {
-        let mut data = ExpressionData::default();
         let source = "{a = 0;}";
-        let _assign_stmt = parse_block(&mut make_input(source), &mut data).unwrap();
+        let (src, mut input) = make_input(source);
+        let mut comp = Component::new(src);
+        let _assign_stmt = parse_block(&mut input, &mut comp).unwrap();
     }
 
     #[test]
     fn test_parse_return() {
-        let mut data = ExpressionData::default();
         let source = "return 0;";
-        let _return_stmt = parse_return(&mut make_input(source), &mut data).unwrap();
+        let (src, mut input) = make_input(source);
+        let mut comp = Component::new(src);
+        let _return_stmt = parse_return(&mut input, &mut comp).unwrap();
     }
 
     #[test]
     fn test_parse_assign() {
-        let mut data = ExpressionData::default();
         let source = "a = 0;";
-        let _assign_stmt = parse_assign(&mut make_input(source), &mut data).unwrap();
+        let (src, mut input) = make_input(source);
+        let mut comp = Component::new(src);
+        let _assign_stmt = parse_assign(&mut input, &mut comp).unwrap();
     }
 }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1,18 +1,19 @@
-use crate::ast::{types::ValType, M};
+use crate::ast::{Component, PrimitiveType, TypeId, ValType};
 use crate::lexer::Token;
 use crate::parser::{ParseInput, ParserError};
 
-pub fn parse_valtype(input: &mut ParseInput) -> Result<M<ValType>, ParserError> {
+pub fn parse_valtype(input: &mut ParseInput, comp: &mut Component) -> Result<TypeId, ParserError> {
     let next = input.next()?;
     let span = next.span.clone();
     let valtype = match next.token {
-        Token::U32 => ValType::U32,
-        Token::U64 => ValType::U64,
-        Token::S32 => ValType::S32,
-        Token::S64 => ValType::S64,
-        Token::F32 => ValType::F32,
-        Token::F64 => ValType::F64,
+        Token::U32 => ValType::Primitive(PrimitiveType::U32),
+        Token::U64 => ValType::Primitive(PrimitiveType::U64),
+        Token::S32 => ValType::Primitive(PrimitiveType::S32),
+        Token::S64 => ValType::Primitive(PrimitiveType::S64),
+        Token::F32 => ValType::Primitive(PrimitiveType::F32),
+        Token::F64 => ValType::Primitive(PrimitiveType::F64),
         _ => return Err(input.unsupported_error("Unsupported value type")),
     };
-    Ok(M::new(valtype, span))
+    let name_id = comp.new_type(valtype, span);
+    Ok(name_id)
 }

--- a/src/stack_map.rs
+++ b/src/stack_map.rs
@@ -2,10 +2,19 @@ use std::cmp;
 use std::collections::HashMap;
 use std::hash::Hash;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct StackMap<K, V> {
     mapping: HashMap<K, V>,
     history: Vec<(K, Option<V>)>,
+}
+
+impl<K, V> std::default::Default for StackMap<K, V> {
+    fn default() -> Self {
+        Self {
+            mapping: Default::default(),
+            history: Default::default(),
+        }
+    }
 }
 
 pub struct StackMapCheckpoint(usize);

--- a/tests/miette.rs
+++ b/tests/miette.rs
@@ -1,0 +1,53 @@
+use thiserror::Error;
+use miette::{NamedSource, Report, SourceSpan, Diagnostic};
+
+#[derive(Error, Debug, Diagnostic)]
+#[error("oops!")]
+struct StructError {
+    // The Source that we're gonna be printing snippets out of.
+    // This can be a String if you don't have or care about file names.
+    #[source_code]
+    src: NamedSource<String>,
+    // Snippets and highlights can be included in the diagnostic!
+    #[label("This bit here")]
+    bad_bit: SourceSpan,
+}
+
+#[derive(Error, Debug, Diagnostic)]
+enum EnumError {
+    #[error("oops!")]
+    Base {
+        // The Source that we're gonna be printing snippets out of.
+        // This can be a String if you don't have or care about file names.
+        #[source_code]
+        src: NamedSource<String>,
+        // Snippets and highlights can be included in the diagnostic!
+        #[label("This bit here")]
+        bad_bit: SourceSpan,
+    }
+}
+
+#[derive(Error, Debug, Diagnostic)]
+enum NestedEnumError {
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Error(#[from] EnumError)
+}
+
+#[test]
+fn test_miette_struct_error() {
+    let src = NamedSource::new("foobar.txt", "[1.3, \"foobar\", false]".to_owned());
+    let error = StructError { src, bad_bit: SourceSpan::from((6, 8)) };
+    println!("{:?}", Report::new(error));
+
+    let src = NamedSource::new("foobar.txt", "[1.3, \"foobar\", false]".to_owned());
+    let error = EnumError::Base { src, bad_bit: SourceSpan::from((6, 8)) };
+    println!("{:?}", Report::new(error));
+
+    let src = NamedSource::new("foobar.txt", "[1.3, \"foobar\", false]".to_owned());
+    let error = EnumError::Base { src, bad_bit: SourceSpan::from((6, 8)) };
+    let error = NestedEnumError::Error(error);
+    println!("{:?}", Report::new(error));
+
+    // panic!();
+}


### PR DESCRIPTION
This refactor
* makes the use of arenas consistent throughout the project,
* splits `Statement` and `Expression` enum payloads into their own structs e.g. `ast::If`,
* makes the type resolution system more flexible and powerful, and
* introduces a new `WithContext` trait and style for defining methods on types that need context.