### PR TITLE
feat: Remove parser backtracking

### DIFF
--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -79,16 +79,14 @@ pub fn parse_ident_expr(
     input: &mut ParseInput,
     comp: &mut Component,
 ) -> Result<ExpressionId, ParserError> {
-    let checkpoint = input.checkpoint();
-    let next = input.next()?;
-    let span = next.span.clone();
-    match next.token.clone() {
+    match &input.peek()?.token {
         Token::Identifier(ident) => {
+            let ident = ident.clone();
+            let span = input.next().unwrap().span;
             let ident = comp.new_name(ident, span.clone());
             Ok(comp.expr_mut().alloc_ident(ident, span))
         }
         _ => {
-            input.restore(checkpoint);
             Err(input.unexpected_token("Expected identifier"))
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -50,11 +50,6 @@ pub struct ParseInput {
     index: usize,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct Checkpoint {
-    index: usize,
-}
-
 impl ParseInput {
     pub fn new(src: crate::Source, tokens: Vec<TokenData>) -> Self {
         ParseInput {
@@ -79,14 +74,6 @@ impl ParseInput {
             description: description.to_string(),
             token: data.token.clone(),
         }
-    }
-
-    pub fn checkpoint(&self) -> Checkpoint {
-        Checkpoint { index: self.index }
-    }
-
-    pub fn restore(&mut self, checkpoint: Checkpoint) {
-        self.index = checkpoint.index
     }
 
     pub fn get_source(&self) -> crate::Source {

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -21,13 +21,13 @@ pub fn parse_block(
 
 /// Parse an identifier
 pub fn parse_ident(input: &mut ParseInput, comp: &mut Component) -> Result<NameId, ParserError> {
-    let checkpoint = input.checkpoint();
-    let next = input.next()?;
-    let span = next.span.clone();
-    match next.token.clone() {
-        Token::Identifier(ident) => Ok(comp.new_name(ident, span)),
+    match &input.peek()?.token {
+        Token::Identifier(ident) => {
+            let ident = ident.clone();
+            let span = input.next().unwrap().span;
+            Ok(comp.new_name(ident, span))
+        }
         _ => {
-            input.restore(checkpoint);
             Err(input.unexpected_token("Expected identifier"))
         }
     }


### PR DESCRIPTION
Backtracking considered dangerous now that parsing mutates arenas.

Changes
* Switched identifier parsing to use `ParseInput::peek`
* Removed `parser::Checkpoint`
* Removed `ParseInput::checkpoint`
* Removed `ParseInput::restore`.