### PR TITLE
chore: Cleanup and testing

### DIFF
--- a/src/ast/component.rs
+++ b/src/ast/component.rs
@@ -149,15 +149,10 @@ pub enum ExternalType {
 #[derive(Debug)]
 pub struct Function {
     pub exported: bool,
-    pub signature: FunctionSignature,
-    pub body: Vec<StatementId>,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct FunctionSignature {
     pub ident: NameId,
     pub arguments: Vec<(NameId, TypeId)>,
     pub return_type: Option<TypeId>,
+    pub body: Vec<StatementId>,
 }
 
 pub trait FnTypeInfo {
@@ -165,7 +160,7 @@ pub trait FnTypeInfo {
     fn get_return_type(&self) -> Option<TypeId>;
 }
 
-impl FnTypeInfo for FunctionSignature {
+impl FnTypeInfo for Function {
     fn get_args(&self) -> &[(NameId, TypeId)] {
         self.arguments.as_slice()
     }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -38,6 +38,17 @@ pub enum PrimitiveType {
     Bool,
 }
 
+impl PrimitiveType {
+    pub fn core_type_mask(&self) -> Option<i32> {
+        use PrimitiveType as P;
+        match self {
+            P::U8 | P::S8 => Some(0xFF),
+            P::U16 | P::S16 => Some(0xFFFF),
+            _ => None,
+        }
+    }
+}
+
 impl ValType {
     pub fn eq(&self, other: &Self, comp: &Component) -> bool {
         match (self, other) {

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -98,10 +98,8 @@ fn parse_literal(
     let span = next.span;
     let literal = match &next.token {
         Token::StringLiteral(_value) => return Err(input.unsupported_error("StringLiteral")),
-        Token::DecIntLiteral(value) => ast::Literal::Integer(*value),
-        Token::DecFloatLiteral(value) => ast::Literal::Float(*value),
-        Token::BinLiteral(value) => ast::Literal::Integer(*value),
-        Token::HexLiteral(value) => ast::Literal::Integer(*value),
+        Token::IntLiteral(value) => ast::Literal::Integer(*value),
+        Token::FloatLiteral(value) => ast::Literal::Float(*value),
         _ => return Err(input.unexpected_token("Parse Literal")),
     };
     Ok(comp.expr_mut().alloc_literal(literal, span))
@@ -215,12 +213,23 @@ mod tests {
     use crate::ast::expressions::{ContextEq, Literal};
 
     #[test]
-    fn parsing_supports_dec_integer() {
+    fn parsing_supports_integers() {
         let cases = [
+            // Decimal
             ("0", 0, make_span(0, 1)),
             ("1", 1, make_span(0, 1)),
             ("32", 32, make_span(0, 2)),
             ("129", 129, make_span(0, 3)),
+            // Binary
+            ("0b0", 0, make_span(0, 3)),
+            ("0b1", 1, make_span(0, 3)),
+            ("0b100000", 32, make_span(0, 8)),
+            ("0b10000001", 129, make_span(0, 10)),
+            // Hexadecimal
+            ("0x0", 0, make_span(0, 3)),
+            ("0x1", 1, make_span(0, 3)),
+            ("0x20", 32, make_span(0, 4)),
+            ("0x81", 129, make_span(0, 4)),
         ];
         for (source, value, span) in cases {
             let (src, mut input) = make_input(source);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,11 +23,11 @@ pub enum ParserError {
         #[label("Unable to parse this code")]
         span: SourceSpan,
     },
-    #[error("Unexpected token {token:?} with description '{description}'")]
+    #[error("{description}")]
     UnexpectedToken {
         #[source_code]
         src: crate::Source,
-        #[label("Here")]
+        #[label("Found {token:?}")]
         span: SourceSpan,
         description: String,
         token: Token,

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -84,7 +84,8 @@ fn parse_return(input: &mut ParseInput, comp: &mut Component) -> Result<Statemen
 fn parse_assign(input: &mut ParseInput, comp: &mut Component) -> Result<StatementId, ParserError> {
     let ident = parse_ident(input, comp)?;
     let start_span = comp.name_span(ident);
-    input.assert_next(Token::Assign, "Assign '='")?;
+    let err_no_assign = "Expected '=' when parsing assignment statement";
+    input.assert_next(Token::Assign, err_no_assign)?;
     let expression = parse_expression(input, comp)?;
     let end_span = input.assert_next(Token::Semicolon, "Semicolon ';'")?;
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -6,13 +6,18 @@ pub fn parse_valtype(input: &mut ParseInput, comp: &mut Component) -> Result<Typ
     let next = input.next()?;
     let span = next.span;
     let valtype = match next.token {
+        Token::Bool => ValType::Primitive(PrimitiveType::Bool),
+        Token::U8 => ValType::Primitive(PrimitiveType::U8),
+        Token::U16 => ValType::Primitive(PrimitiveType::U16),
         Token::U32 => ValType::Primitive(PrimitiveType::U32),
         Token::U64 => ValType::Primitive(PrimitiveType::U64),
+        Token::S8 => ValType::Primitive(PrimitiveType::S8),
+        Token::S16 => ValType::Primitive(PrimitiveType::S16),
         Token::S32 => ValType::Primitive(PrimitiveType::S32),
         Token::S64 => ValType::Primitive(PrimitiveType::S64),
         Token::F32 => ValType::Primitive(PrimitiveType::F32),
         Token::F64 => ValType::Primitive(PrimitiveType::F64),
-        _ => return Err(input.unsupported_error("Unsupported value type")),
+        _ => return Err(input.unexpected_token("Not a legal type")),
     };
     let name_id = comp.new_type(valtype, span);
     Ok(name_id)

--- a/tests/bad-programs/global-without-annotation.claw
+++ b/tests/bad-programs/global-without-annotation.claw
@@ -1,0 +1,5 @@
+let a = 0;
+
+func foo() -> u32 {
+    return a;
+}

--- a/tests/bad-programs/global-without-initialization.claw
+++ b/tests/bad-programs/global-without-initialization.claw
@@ -1,0 +1,5 @@
+let a: u32;
+
+func foo() -> u32 {
+    return a;
+}

--- a/tests/bad-programs/invalid-token.claw
+++ b/tests/bad-programs/invalid-token.claw
@@ -1,0 +1,3 @@
+func foo($a: u32) -> u32 {
+    return $a;
+}

--- a/tests/programs/arithmetic.claw
+++ b/tests/programs/arithmetic.claw
@@ -1,0 +1,5 @@
+export func test-u8-masking() -> bool {
+    let zero: u8 = 255 + 1;
+    return zero == 0;
+}
+

--- a/tests/programs/claw.wit
+++ b/tests/programs/claw.wit
@@ -1,5 +1,9 @@
 package claw:samples;
 
+world arithmetic {
+    export test-u8-masking: func() -> bool;
+}
+
 world compare {
     export min-u32: func(left: u32, right: u32) -> u32;
     export max-u32: func(left: u32, right: u32) -> u32;

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -52,6 +52,18 @@ impl Runtime {
 }
 
 #[test]
+fn test_arithmetic() {
+    bindgen!("arithmetic" in "tests/programs");
+
+    let mut runtime = Runtime::new("arithmetic");
+
+    let (arithmetic, _) =
+        Arithmetic::instantiate(&mut runtime.store, &runtime.component, &runtime.linker).unwrap();
+
+    assert!(arithmetic.call_test_u8_masking(&mut runtime.store).unwrap());
+}
+
+#[test]
 fn test_counter() {
     bindgen!("counter" in "tests/programs");
 


### PR DESCRIPTION
* Apply bit mask after small integer type operations
* Simplify `ast::Function`
* Simplify number literal token types
* Improve error messages
* Fix bug in let statement type resolution