### PR TITLE
Fix missing null check for resolved global in Assign statement

### DIFF
--- a/crates/resolver/src/statement.rs
+++ b/crates/resolver/src/statement.rs
@@ -66,7 +66,13 @@ impl ResolveStatement for ast::Assign {
 
         match item {
             ItemId::Global(global) => {
-                let global = resolver.component.get_global(global);
+                let global = resolver.component.get_global(global).ok_or_else(|| {
+                    ResolverError::UndefinedGlobal {
+                        src: resolver.component.source(),
+                        span: resolver.component.name_span(self.ident),
+                        ident: resolver.component.get_name(self.ident).to_string(),
+                    }
+                })?;
                 resolver.set_expr_type(self.expression, ResolvedType::Defined(global.type_id));
 
                 if !global.mutable {


### PR DESCRIPTION
This PR adds a null check for the resolved global in the Assign statement handler in `crates/resolver/src/statement.rs`.

**Problem:**
The `Assign` statement handler called `resolver.component.get_global(global)` without checking if the global exists. If the global was not found, this could cause a panic or undefined behavior.

**Solution:**
Added a null check using `.ok_or_else()` to return a `ResolverError::UndefinedGlobal` error when the global is not found, preventing potential panics and providing a clear error message to the user.

**Changes:**
- Modified the `ItemId::Global` match arm in the `Assign::setup_resolve` implementation
- Added error handling for missing globals with appropriate error context (source, span, identifier name)

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.